### PR TITLE
chore(logging): remove que-go worker log from stderr

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -117,7 +117,8 @@ func (w *Worker) WorkOne() (didWork bool) {
 	if err = j.Delete(); err != nil {
 		log.Printf("attempting to delete job %d: %v", j.ID, err)
 	}
-	log.Printf("event=job_worked job_id=%d job_type=%s", j.ID, j.Type)
+	// This is not the ERROR-level log, but rather just INFO-level. We just disable it, because it's too noisy.
+	//log.Printf("event=job_worked job_id=%d job_type=%s", j.ID, j.Type)
 	return
 }
 


### PR DESCRIPTION
## Problem
Currently, at talon-service container logs, we see the [errors](https://console.cloud.google.com/kubernetes/deployment/us-east4-a/talon-prod-us-east4-private/bilt/talon-service/logs?project=talon-prod-us-east4):

<img width="962" alt="logs" src="https://user-images.githubusercontent.com/4104908/220071848-7e298b01-10bf-4570-a258-4b779c68dfd7.png">

But it's not the errors, but rather just INFO-level logs.
que-go uses go logger, which by default initialize Stderr as writer:

`var std = New(os.Stderr, "", LstdFlags)` 

## Solution
Because this logging is not really important we can delete it.

## Notes

On the code level logging is added at line 120 in the file

`vendor/github.com/talon-one/que-go/worker.go`