### PR TITLE
fix(Webhook): adjust insert statement for execEnqueue function

### DIFF
--- a/que.go
+++ b/que.go
@@ -209,7 +209,7 @@ func execEnqueue(j *Job, txn pgxV4.Tx) error {
 		args.Status = pgtype.Present
 	}
 
-	_, err := txn.Exec(context.Background(), "que_insert_job", queue, priority, runAt, j.Type, args)
+	_, err := txn.Exec(context.Background(), sqlInsertJob, queue, priority, runAt, j.Type, args)
 	return err
 }
 


### PR DESCRIPTION
## Problem
Please see related [issue](https://app.shortcut.com/talonone/story/25777/broken-transactional-logic-in-go-queue)

Right now, we've got a problem because of some changes made in the related ticket. We're trying to use the `que_insert_job` statement key inside the `execEnqueue` function. But it's not working. This is because we're using a transaction now and it doesn't know about the `preparedStatement` map.

## Solution
We can fix this by directly giving the SQL statement to the `txn.Exec()` call in the `execEnqueue` function. This will make sure the transaction knows what to do and should solve the problem.